### PR TITLE
feat: add sourcemap to Utils to expose parsing internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,33 @@ export class TestCommand13 implements LeafCommand {
 
 By this setup I cannot call `TestCommand13` with both options `option1` and `option2`, but I have to pass at least one of these.
 
+### Check where the value of an option or argument originates from
+
+Suppose you have an option which has a default value and may also be specified via `process.env`. To indicate this, the option receives the `default` and `envKey` properties.
+
+```ts
+import { Option } from 'furious-commander'
+
+@Option({ key: 'host', description: 'Host', envKey: 'HOST', default: 'http://localhost' })
+public host!: string;
+```
+
+Later on, you may want to know where its value came from - whether it was specified with `--host` explicitly, got its value from `process.env`, or used the default value.
+
+To learn this information, use `Utils.getSourcemap()` after calling the `cli`.
+
+```ts
+import { Utils } from 'furious-commander'
+
+process.env.HOST = '...'
+
+const sourcemap = Utils.getSourcemap()
+
+sourcemap.host // 'env'
+```
+
+`sourcemap[key]` holds values `'explicit'`, `'env'`, `'default'` or `undefined` accordingly.
+
 ## Setup your project
 
 In order to use decorators in your project (until it's not available in vanilla JS) you should use `typescript` with the following configuration:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "cafe-args": "^1.0.6",
+        "cafe-args": "^1.0.7",
         "reflect-metadata": "^0.1.13"
       },
       "devDependencies": {
@@ -1879,7 +1879,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -3316,9 +3315,9 @@
       }
     },
     "node_modules/cafe-args": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.6.tgz",
-      "integrity": "sha512-R+43XOg5ZelcOYGs1pzVO8DkLj3Ak6HgQFdXcQetz7Hjml906+pbFxRoit0Vjs6mrz4EhAyrFMuo/k7GJykwiA=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.7.tgz",
+      "integrity": "sha512-wJhyV1hmHo1P8I5Arp4hvzz+4gY1sTCJpaGrkjfywYKTAukGjjdXScq0XE9xgW9sAu9kCemTsoYxpjiPG2mUOQ=="
     },
     "node_modules/call-bind": {
       "version": "1.0.0",
@@ -4160,8 +4159,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -6451,7 +6449,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -13882,9 +13879,9 @@
       }
     },
     "cafe-args": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.6.tgz",
-      "integrity": "sha512-R+43XOg5ZelcOYGs1pzVO8DkLj3Ak6HgQFdXcQetz7Hjml906+pbFxRoit0Vjs6mrz4EhAyrFMuo/k7GJykwiA=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.7.tgz",
+      "integrity": "sha512-wJhyV1hmHo1P8I5Arp4hvzz+4gY1sTCJpaGrkjfywYKTAukGjjdXScq0XE9xgW9sAu9kCemTsoYxpjiPG2mUOQ=="
     },
     "call-bind": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "webpack-cli": "^4.3.0"
   },
   "dependencies": {
-    "cafe-args": "^1.0.6",
+    "cafe-args": "^1.0.7",
     "reflect-metadata": "^0.1.13"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import { ExternalOption, getExternalOption, getOption, IOption, Option } from '.
 import { createDefaultPrinter, Printer } from './printer'
 import { getCommandInstance } from './utils'
 
+let sourcemap: Record<string, 'default' | 'env' | 'explicit'> = {}
+
 interface ICli {
   /**
    * Array of the **Root** Command Classes
@@ -148,6 +150,7 @@ class CommandBuilder {
     }
 
     this.context = this.parser.parse(argv)
+    sourcemap = this.context.sourcemap
 
     if (this.context.exitReason || typeof this.context === 'string' || !this.context.command?.meta?.instance) {
       return
@@ -285,5 +288,6 @@ export { GroupCommand, LeafCommand, Argument, ExternalOption, Option, Aggregatio
 export const Utils = {
   isGroupCommand,
   getCommandInstance,
+  sourcemap,
 }
 export default cli

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,9 @@ import { ExternalOption, getExternalOption, getOption, IOption, Option } from '.
 import { createDefaultPrinter, Printer } from './printer'
 import { getCommandInstance } from './utils'
 
-let sourcemap: Record<string, 'default' | 'env' | 'explicit'> = {}
+type Sourcemap = Record<string, 'default' | 'env' | 'explicit'>
+
+let sourcemap: Sourcemap = {}
 
 interface ICli {
   /**
@@ -283,11 +285,22 @@ export async function cli(options: ICli): Promise<CommandBuilder> {
   return builder
 }
 
-export { GroupCommand, LeafCommand, Argument, ExternalOption, Option, Aggregation, Command, InitedCommand, IOption }
+export {
+  GroupCommand,
+  LeafCommand,
+  Argument,
+  ExternalOption,
+  Option,
+  Aggregation,
+  Command,
+  InitedCommand,
+  IOption,
+  Sourcemap,
+}
 
 export const Utils = {
   isGroupCommand,
   getCommandInstance,
-  sourcemap,
+  getSourcemap: (): Sourcemap => sourcemap,
 }
 export default cli


### PR DESCRIPTION
This PR exposes an object - `Utils.sourcemap` - which can be used to track down where options and arguments originate from.

E.g. if the option `host` was left unspecified, but has a default of `localhost`, `Utils.sourcemap.host` would be `'default'`.

The 4 outcomes are: `env` (via `envKey`), `explicit`, `default`, and not being specified.