### PR TITLE
chore: update cafe-args version to 1.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "cafe-args": "^1.0.9",
+        "cafe-args": "^1.0.11",
         "reflect-metadata": "^0.1.13"
       },
       "devDependencies": {
@@ -1879,7 +1879,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -3316,9 +3315,9 @@
       }
     },
     "node_modules/cafe-args": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.9.tgz",
-      "integrity": "sha512-jtsppavZLffY6m16CtbYsqycLhpqUWjbqnJsb62WCqi6HWiiQExAnZF9rNvwq8Co7thdUkQamgwhR45hVtSRkA=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.11.tgz",
+      "integrity": "sha512-gvwz556GAeOn0AbEat6MDoLcE08wJ48rdJrhEzPYeosqstHOg5X+4Hf81nJqHMDeHHeWA4TXSdBsf3dLsMKECA=="
     },
     "node_modules/call-bind": {
       "version": "1.0.0",
@@ -4160,8 +4159,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -6451,7 +6449,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -13882,9 +13879,9 @@
       }
     },
     "cafe-args": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.9.tgz",
-      "integrity": "sha512-jtsppavZLffY6m16CtbYsqycLhpqUWjbqnJsb62WCqi6HWiiQExAnZF9rNvwq8Co7thdUkQamgwhR45hVtSRkA=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.11.tgz",
+      "integrity": "sha512-gvwz556GAeOn0AbEat6MDoLcE08wJ48rdJrhEzPYeosqstHOg5X+4Hf81nJqHMDeHHeWA4TXSdBsf3dLsMKECA=="
     },
     "call-bind": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "webpack-cli": "^4.3.0"
   },
   "dependencies": {
-    "cafe-args": "^1.0.9",
+    "cafe-args": "^1.0.11",
     "reflect-metadata": "^0.1.13"
   }
 }


### PR DESCRIPTION
1.0.10:
 * MIT license
 * infinite arguments

1.0.11:
 * Fix symmetric required options sibling bug