### PR TITLE
chore: update parser version and fix audit issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
-        "cafe-args": "^1.0.11",
+        "cafe-args": "^1.0.12",
         "reflect-metadata": "^0.1.13"
       },
       "devDependencies": {
@@ -1879,7 +1879,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -3316,9 +3315,9 @@
       }
     },
     "node_modules/cafe-args": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.11.tgz",
-      "integrity": "sha512-gvwz556GAeOn0AbEat6MDoLcE08wJ48rdJrhEzPYeosqstHOg5X+4Hf81nJqHMDeHHeWA4TXSdBsf3dLsMKECA=="
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.12.tgz",
+      "integrity": "sha512-jRfD7pctiHfvsen0jCp7eWg2+gWRuctG1NM7jntD48hVRyLk+XiB4Nm6658EBUUEnnS8XEH/KJrqSGue5kHxJw=="
     },
     "node_modules/call-bind": {
       "version": "1.0.0",
@@ -4160,8 +4159,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -6451,7 +6449,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -13882,9 +13879,9 @@
       }
     },
     "cafe-args": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.11.tgz",
-      "integrity": "sha512-gvwz556GAeOn0AbEat6MDoLcE08wJ48rdJrhEzPYeosqstHOg5X+4Hf81nJqHMDeHHeWA4TXSdBsf3dLsMKECA=="
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.12.tgz",
+      "integrity": "sha512-jRfD7pctiHfvsen0jCp7eWg2+gWRuctG1NM7jntD48hVRyLk+XiB4Nm6658EBUUEnnS8XEH/KJrqSGue5kHxJw=="
     },
     "call-bind": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5434,9 +5434,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-      "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+      "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -7652,9 +7652,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "node_modules/lodash._reinterpolate": {
@@ -8609,9 +8609,9 @@
       }
     },
     "node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "node_modules/read-pkg/node_modules/normalize-package-data": {
@@ -15571,9 +15571,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-      "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+      "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -17337,9 +17337,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash._reinterpolate": {
@@ -18073,9 +18073,9 @@
       },
       "dependencies": {
         "hosted-git-info": {
-          "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
           "dev": true
         },
         "normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "webpack-cli": "^4.3.0"
   },
   "dependencies": {
-    "cafe-args": "^1.0.11",
+    "cafe-args": "^1.0.12",
     "reflect-metadata": "^0.1.13"
   }
 }


### PR DESCRIPTION
`cafe-args` `1.0.12` fixes options printed twice when present both in original and sibling commands.

Other fix:

```
lodash  <4.17.21
Severity: high
Command Injection - https://npmjs.com/advisories/1673
```