### PR TITLE
feat: add autocomplete, noErrors and conflict printing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "cafe-args": "^1.0.15",
-        "omelette": "*",
+        "omelette": "0.4.15-1",
         "reflect-metadata": "^0.1.13"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
-        "cafe-args": "^1.0.15",
+        "cafe-args": "^1.0.16",
         "omelette": "0.4.15-1",
         "reflect-metadata": "^0.1.13"
       },
@@ -3323,9 +3323,9 @@
       }
     },
     "node_modules/cafe-args": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.15.tgz",
-      "integrity": "sha512-f/XVrBvdH2w3JcMknyWB6pWBRCmRu9bxDeSQC6kSsseumfcBwfZCELcwKOlPeDovdsyj/hfHXjlEBGZskj5Cmw=="
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.16.tgz",
+      "integrity": "sha512-dsWC2FcZK+3qO9usxg7EnhEchsHOyjx7k8+s3rEF9BOyU8OEWsMR3pPiX9Uf7dBnuYtigKciJV/jexUx+7xwww=="
     },
     "node_modules/call-bind": {
       "version": "1.0.0",
@@ -13901,9 +13901,9 @@
       }
     },
     "cafe-args": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.15.tgz",
-      "integrity": "sha512-f/XVrBvdH2w3JcMknyWB6pWBRCmRu9bxDeSQC6kSsseumfcBwfZCELcwKOlPeDovdsyj/hfHXjlEBGZskj5Cmw=="
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.16.tgz",
+      "integrity": "sha512-dsWC2FcZK+3qO9usxg7EnhEchsHOyjx7k8+s3rEF9BOyU8OEWsMR3pPiX9Uf7dBnuYtigKciJV/jexUx+7xwww=="
     },
     "call-bind": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "cafe-args": "^1.0.13",
+        "omelette": "*",
         "reflect-metadata": "^0.1.13"
       },
       "devDependencies": {
@@ -23,6 +24,7 @@
         "@types/glob": "^7.1.3",
         "@types/jest": "^26.0.19",
         "@types/node": "^14.14.16",
+        "@types/omelette": "^0.4.1",
         "@types/terser-webpack-plugin": "^5.0.2",
         "@types/webpack": "^5.28.0",
         "@types/webpack-bundle-analyzer": "^4.4.0",
@@ -2315,6 +2317,12 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "node_modules/@types/omelette": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/omelette/-/omelette-0.4.1.tgz",
+      "integrity": "sha512-OdafPpsN3JKsIYmPggTOIgm6f7c33rOWHO6XeQBcSx8RHPZXNsB5YbkupNxreuWM06qj8fgFuD8IgBMaTBLvzw==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -8190,6 +8198,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/omelette": {
+      "version": "0.4.15-1",
+      "resolved": "https://registry.npmjs.org/omelette/-/omelette-0.4.15-1.tgz",
+      "integrity": "sha512-sHU/IPll6uGCwESBH8HLZP1+sKmi2dXFy81u5oHvYnWaxJFvQ2A/QmCe7Qe0ce1DQONy85OSSTC4duZ/K5vXKA==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -13029,6 +13045,12 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "@types/omelette": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/omelette/-/omelette-0.4.1.tgz",
+      "integrity": "sha512-OdafPpsN3JKsIYmPggTOIgm6f7c33rOWHO6XeQBcSx8RHPZXNsB5YbkupNxreuWM06qj8fgFuD8IgBMaTBLvzw==",
+      "dev": true
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -17770,6 +17792,11 @@
       "requires": {
         "isobject": "^3.0.1"
       }
+    },
+    "omelette": {
+      "version": "0.4.15-1",
+      "resolved": "https://registry.npmjs.org/omelette/-/omelette-0.4.15-1.tgz",
+      "integrity": "sha512-sHU/IPll6uGCwESBH8HLZP1+sKmi2dXFy81u5oHvYnWaxJFvQ2A/QmCe7Qe0ce1DQONy85OSSTC4duZ/K5vXKA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
-        "cafe-args": "^1.0.13",
+        "cafe-args": "^1.0.15",
         "omelette": "*",
         "reflect-metadata": "^0.1.13"
       },
@@ -3323,9 +3323,9 @@
       }
     },
     "node_modules/cafe-args": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.13.tgz",
-      "integrity": "sha512-5ujwBCi+0e30wM0uyHmgveWD9hNdUtI7FqfUlBbRt0zFV7KLlJQPMI+mcP0uEGZ6X6+NeJDUcvF1WkR3WX0edQ=="
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.15.tgz",
+      "integrity": "sha512-f/XVrBvdH2w3JcMknyWB6pWBRCmRu9bxDeSQC6kSsseumfcBwfZCELcwKOlPeDovdsyj/hfHXjlEBGZskj5Cmw=="
     },
     "node_modules/call-bind": {
       "version": "1.0.0",
@@ -13901,9 +13901,9 @@
       }
     },
     "cafe-args": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.13.tgz",
-      "integrity": "sha512-5ujwBCi+0e30wM0uyHmgveWD9hNdUtI7FqfUlBbRt0zFV7KLlJQPMI+mcP0uEGZ6X6+NeJDUcvF1WkR3WX0edQ=="
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.15.tgz",
+      "integrity": "sha512-f/XVrBvdH2w3JcMknyWB6pWBRCmRu9bxDeSQC6kSsseumfcBwfZCELcwKOlPeDovdsyj/hfHXjlEBGZskj5Cmw=="
     },
     "call-bind": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "webpack-cli": "^4.3.0"
   },
   "dependencies": {
-    "cafe-args": "^1.0.13",
+    "cafe-args": "^1.0.15",
     "omelette": "*",
     "reflect-metadata": "^0.1.13"
   }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "webpack-cli": "^4.3.0"
   },
   "dependencies": {
-    "cafe-args": "^1.0.16",
+    "cafe-args": "1.0.16",
     "omelette": "0.4.15-1",
     "reflect-metadata": "^0.1.13"
   }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "webpack-cli": "^4.3.0"
   },
   "dependencies": {
-    "cafe-args": "^1.0.15",
+    "cafe-args": "^1.0.16",
     "omelette": "0.4.15-1",
     "reflect-metadata": "^0.1.13"
   }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.19",
     "@types/node": "^14.14.16",
+    "@types/omelette": "^0.4.1",
     "@types/terser-webpack-plugin": "^5.0.2",
     "@types/webpack": "^5.28.0",
     "@types/webpack-bundle-analyzer": "^4.4.0",
@@ -68,6 +69,7 @@
   },
   "dependencies": {
     "cafe-args": "^1.0.13",
+    "omelette": "*",
     "reflect-metadata": "^0.1.13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "cafe-args": "^1.0.15",
-    "omelette": "*",
+    "omelette": "0.4.15-1",
     "reflect-metadata": "^0.1.13"
   }
 }

--- a/src/argument.ts
+++ b/src/argument.ts
@@ -17,6 +17,7 @@ export interface IArgument<T = unknown> {
   conflicts?: string
   defaultDescription?: string
   envKey?: string
+  noErrors?: boolean
 }
 
 /**

--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -17,7 +17,7 @@ export function autocomplete(parser: Argv.Parser, command: string): Promise<void
 
     completion.init()
 
-    if (process.argv.find(item => item === '--install-autocomplete')) {
+    if (process.argv.includes('--install-autocomplete')) {
       completion.setupShellInitFile()
       exit(0)
     }

--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -1,0 +1,25 @@
+import * as Argv from 'cafe-args'
+import omelette from 'omelette'
+import { exit } from 'process'
+
+export function autocomplete(parser: Argv.Parser, command: string): Promise<void> {
+  return new Promise(resolve => {
+    const completion = omelette(command)
+
+    completion.on('complete', (fragment, { line, reply }) => {
+      const relevantPart = line.slice(command.length + 1)
+      reply(parser.suggest(relevantPart))
+    })
+
+    completion.next(() => {
+      resolve()
+    })
+
+    completion.init()
+
+    if (process.argv.find(item => item === '--install-autocomplete')) {
+      completion.setupShellInitFile()
+      exit(0)
+    }
+  })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,13 +147,12 @@ class CommandBuilder {
     this.initedCommands = []
   }
 
-  private autocomplete(options: ICli): Promise<void> {
+  private autocomplete(command: string): Promise<void> {
     return new Promise(resolve => {
-      const applicationName = options.application?.command || 'undefined'
-      const completion = omelette(applicationName)
+      const completion = omelette(command)
 
       completion.on('complete', (fragment, { line, reply }) => {
-        const relevantPart = line.slice(applicationName.length + 1)
+        const relevantPart = line.slice(command.length + 1)
         reply(this.parser.suggest(relevantPart))
       })
 
@@ -184,7 +183,9 @@ class CommandBuilder {
       this.initCommandInstance(this.parser, initedCommand)
     }
 
-    await this.autocomplete(options)
+    if (options.application?.command) {
+      await this.autocomplete(options.application?.command)
+    }
 
     this.context = await this.parser.parse(test ? argv : argv.slice(2))
     sourcemap = this.context.sourcemap

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,12 +169,7 @@ class CommandBuilder {
     })
   }
 
-  public async initCommandClasses(
-    argv: string[],
-    commands: { new (): Command }[],
-    options: ICli,
-    test: boolean,
-  ): Promise<void> {
+  public async initCommandClasses(argv: string[], commands: { new (): Command }[], options: ICli): Promise<void> {
     for (const CommandClass of commands) {
       this.initedCommands.push(this.initCommandClass(CommandClass))
     }
@@ -187,7 +182,7 @@ class CommandBuilder {
       await this.autocomplete(options.application?.command)
     }
 
-    this.context = await this.parser.parse(test ? argv : argv.slice(2))
+    this.context = await this.parser.parse(argv)
     sourcemap = this.context.sourcemap
 
     if (this.context.exitReason || typeof this.context === 'string' || !this.context.command?.meta?.instance) {
@@ -306,12 +301,7 @@ export async function cli(options: ICli): Promise<CommandBuilder> {
     }
   }
   const builder = new CommandBuilder(parser)
-  await builder.initCommandClasses(
-    testArguments || process.argv,
-    rootCommandClasses,
-    options,
-    Boolean(testArguments) || false,
-  )
+  await builder.initCommandClasses(testArguments || process.argv.slice(2), rootCommandClasses, options)
 
   if (builder.runnable) {
     try {

--- a/src/option.ts
+++ b/src/option.ts
@@ -18,6 +18,7 @@ export interface IOption<T = unknown> {
   defaultDescription?: string
   handler?: () => void
   envKey?: string
+  noErrors?: boolean
 }
 
 /**


### PR DESCRIPTION
Autocomplete uses the https://github.com/f/omelette library for generating the bash, zsh and fish compatible completion scripts.

Pressing tab will call the command to request autocomplete suggestions. This is caught by omelette, and passes an event to cafe-args. Cafe-args then suggests groups, commands and flags.

To install autocompletion, the command will have to be called with the hardcoded flag `--install-autocomplete` once. All future changes are picked up automatically, since this is using dynamic autosuggestions.

---

The `noErrors` property disables throwing exceptions for missing `required` properties. This is a way for application developers to say "trust me, I know what I am doing, I will make sure it is set in my code". For example, showing pickers that cannot be displayed during parse-time is a real world use case.

Example:

```
{ key: 'user', required: true, noErrors: true }
```

---

Adds message about conflicting options to help:

Single: 

```
Only one is required: [silent] or [verbose]
```

Multi: 

```
Only one is required: [silent] or [verbose], [file] or [stdout]
```
