### PR TITLE
feat: add numerical units and formatting and hex-string type

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Furthermore, you can use the following shorthand units:
 
 There is a built-in `hex-string` type that does the following checks and transformations:
 
-- Ensures only `a-z` and `0-9` characters are given
+- Ensures only `a-f` and `0-9` characters are given
 - Allows uppercase, but transforms to lowercase
 - Allows `0x` prefix, but omits it
 - Checks for even length, unless `oddLength: true` property is given

--- a/README.md
+++ b/README.md
@@ -220,6 +220,37 @@ Usage:
 furious-commander http get <url> [OPTIONS]
 ```
 
+### Human-Readable Numbers
+
+Numbers and BigInts may be formatted with underscores (`_`) at will for better readability:
+
+```
+--price 100_000_000
+```
+
+Underscores are simply omitted before the parsing cycle. They can appear anywhere and you may have as many of them as you want.
+
+Furthermore, you can use the following shorthand units:
+
+```
+| Unit     | Lower | Upper | Example  |
+|----------|-------|-------|----------|
+| Thousand | k     | K     | 120K     |
+| Million  | m     | M     | 84m      |
+| Billion  | b     | B     | 200_000B |
+| Trillion | t     | T     | 19t      |
+```
+
+### Hex-Strings
+
+There is a built-in `hex-string` type that does the following checks and transformations:
+
+- Ensures only `a-z` and `0-9` characters are given
+- Allows uppercase, but transforms to lowercase
+- Allows `0x` prefix, but omits it
+- Checks for even length, unless `oddLength: true` property is given
+- Obeys `length`, `minimumLength` and `maximumLength` rules
+
 ## Setup your project
 
 In order to use decorators in your project (until it's not available in vanilla JS) you should use `typescript` with the following configuration:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "cafe-args": "^1.0.16",
+        "cafe-args": "^1.0.19",
         "omelette": "0.4.15-1",
         "reflect-metadata": "^0.1.13"
       },
@@ -3269,22 +3269,26 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
-      "integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
       "dev": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001165",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.621",
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.67"
+        "node-releases": "^1.1.71"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/bser": {
@@ -3323,9 +3327,9 @@
       }
     },
     "node_modules/cafe-args": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.16.tgz",
-      "integrity": "sha512-dsWC2FcZK+3qO9usxg7EnhEchsHOyjx7k8+s3rEF9BOyU8OEWsMR3pPiX9Uf7dBnuYtigKciJV/jexUx+7xwww=="
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.19.tgz",
+      "integrity": "sha512-PS63Mu2SFI7ats6wvxoMFJZFqBkoDHlxv2FKYHTbo7ZST1VlR4t6bHbh4ftmEH65Xe7m1sCoCqCtLd6C8qzLmA=="
     },
     "node_modules/call-bind": {
       "version": "1.0.0",
@@ -3370,10 +3374,14 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001171",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001171.tgz",
-      "integrity": "sha512-5Alrh8TTYPG9IH4UkRqEBZoEToWRLvPbSQokvzSz0lii8/FOWKG4keO1HoYfPWs8IF/NH/dyNPg1cmJGvV3Zlg==",
-      "dev": true
+      "version": "1.0.30001235",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001235.tgz",
+      "integrity": "sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -3553,9 +3561,9 @@
       "dev": true
     },
     "node_modules/colorette": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
     "node_modules/combined-stream": {
@@ -4050,9 +4058,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.633",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.633.tgz",
-      "integrity": "sha512-bsVCsONiVX1abkWdH7KtpuDAhsQ3N3bjPYhROSAXE78roJKet0Y5wznA14JE9pzbwSZmSMAW6KiKYf1RvbTJkA==",
+      "version": "1.3.749",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.749.tgz",
+      "integrity": "sha512-F+v2zxZgw/fMwPz/VUGIggG4ZndDsYy0vlpthi3tjmDZlcfbhN5mYW0evXUsBr2sUtuDANFtle410A9u/sd/4A==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -8041,9 +8049,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.67",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-      "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
+      "version": "1.1.72",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+      "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
       "dev": true
     },
     "node_modules/normalize-package-data": {
@@ -10921,12 +10929,24 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml-name-validator": {
@@ -13856,16 +13876,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
-      "integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001165",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.621",
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.67"
+        "node-releases": "^1.1.71"
       }
     },
     "bser": {
@@ -13901,9 +13921,9 @@
       }
     },
     "cafe-args": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.16.tgz",
-      "integrity": "sha512-dsWC2FcZK+3qO9usxg7EnhEchsHOyjx7k8+s3rEF9BOyU8OEWsMR3pPiX9Uf7dBnuYtigKciJV/jexUx+7xwww=="
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.19.tgz",
+      "integrity": "sha512-PS63Mu2SFI7ats6wvxoMFJZFqBkoDHlxv2FKYHTbo7ZST1VlR4t6bHbh4ftmEH65Xe7m1sCoCqCtLd6C8qzLmA=="
     },
     "call-bind": {
       "version": "1.0.0",
@@ -13939,9 +13959,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001171",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001171.tgz",
-      "integrity": "sha512-5Alrh8TTYPG9IH4UkRqEBZoEToWRLvPbSQokvzSz0lii8/FOWKG4keO1HoYfPWs8IF/NH/dyNPg1cmJGvV3Zlg==",
+      "version": "1.0.30001235",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001235.tgz",
+      "integrity": "sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==",
       "dev": true
     },
     "capture-exit": {
@@ -14092,9 +14112,9 @@
       "dev": true
     },
     "colorette": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
     "combined-stream": {
@@ -14500,9 +14520,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.633",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.633.tgz",
-      "integrity": "sha512-bsVCsONiVX1abkWdH7KtpuDAhsQ3N3bjPYhROSAXE78roJKet0Y5wznA14JE9pzbwSZmSMAW6KiKYf1RvbTJkA==",
+      "version": "1.3.749",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.749.tgz",
+      "integrity": "sha512-F+v2zxZgw/fMwPz/VUGIggG4ZndDsYy0vlpthi3tjmDZlcfbhN5mYW0evXUsBr2sUtuDANFtle410A9u/sd/4A==",
       "dev": true
     },
     "emittery": {
@@ -17671,9 +17691,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.67",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-      "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
+      "version": "1.1.72",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+      "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
       "dev": true
     },
     "normalize-package-data": {
@@ -19993,10 +20013,11 @@
       }
     },
     "ws": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
-      "dev": true
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "webpack-cli": "^4.3.0"
   },
   "dependencies": {
-    "cafe-args": "1.0.16",
+    "cafe-args": "1.0.19",
     "omelette": "0.4.15-1",
     "reflect-metadata": "^0.1.13"
   }

--- a/src/argument.ts
+++ b/src/argument.ts
@@ -17,6 +17,10 @@ export interface IArgument<T = unknown> {
   conflicts?: string
   defaultDescription?: string
   envKey?: string
+  length?: number
+  minimumLength?: number
+  maximumLength?: number
+  oddLength?: boolean
   noErrors?: boolean
 }
 

--- a/src/option.ts
+++ b/src/option.ts
@@ -18,6 +18,10 @@ export interface IOption<T = unknown> {
   defaultDescription?: string
   handler?: () => void
   envKey?: string
+  length?: number
+  minimumLength?: number
+  maximumLength?: number
+  oddLength?: boolean
   noErrors?: boolean
 }
 


### PR DESCRIPTION
New parser adds some new features:

* Numbers and BigInts can be formatted with underscore `_` for better readability, e.g. `--price 100_000_000`
* Numbers and BigInts can be postfixed with units `kKmMbBtT` for better readability, e.g. `--price 100M`
* The previous 2 can be mixed, e.g. `--amount 100_000T`
* New `hex-string` type - checks for even length, handles `0x` prefix, handles mixed case and always returns lowercase
* New `length`, `minimumLength`, `maximumLength` properties for strings and hexstrings