### PR TITLE
feat: conditional required property

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ If you build successfully your cli project (e.g. `#!/usr/bin/env node` presents 
 
 This will invoke the testCommand's (async) `run` method, after its fields initialized by Furious Commander.
 
+### Conditional Required
+
+When an option is required, you can simply specify `{ required: true }` and the parser will print a helpful error message every time the user tries running your application without providing that option.
+
+This may not always be your use-case though. Let's say you have an `--interactive` global option, which enables some features, such as allowing the user to provide a value (for that option) in your application logic, after the parser has run.
+
+For such cases, the `required` property can take `{ when: string }` and `{ unless: string }` values, where the strings represent the dependee keys.
+
+Following the previous example, you may want to specify `{ required: { unless: 'interactive' } }`, and the option will no longer throw error when running with the `--interactive` option (or its alias).
+
+The reverse of this situation when you have these features enabled by default, but your application has a `--silent` or `--quiet` mode, where you do not allow any interactivity and the required options must all be passed beforehand. To indicate this, use `{ required: { when: 'quiet' } }`.
+
 ### Aggregation
 
 The framework support aggregated relations between independent commands.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "cafe-args": "1.0.21",
+        "cafe-args": "1.0.22",
         "omelette": "0.4.15-1",
         "reflect-metadata": "^0.1.13"
       },
@@ -3327,9 +3327,9 @@
       }
     },
     "node_modules/cafe-args": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.21.tgz",
-      "integrity": "sha512-cuDGWb5xjoGNrzZ6L2vfd0jn+9ZWj5j0d0O/SOZlLxlgiPxewmnh95vYwtOgvCOrEHtiVr76/O5FbVITMXHKcw=="
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.22.tgz",
+      "integrity": "sha512-mJ1goOs36mLx+VPYBtAm949H0Br6OXuJ9gwqtCYr2paNophYBsheE/BREiOwrWudqrjttICHBG5ubffEeu3YnQ=="
     },
     "node_modules/call-bind": {
       "version": "1.0.0",
@@ -13921,9 +13921,9 @@
       }
     },
     "cafe-args": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.21.tgz",
-      "integrity": "sha512-cuDGWb5xjoGNrzZ6L2vfd0jn+9ZWj5j0d0O/SOZlLxlgiPxewmnh95vYwtOgvCOrEHtiVr76/O5FbVITMXHKcw=="
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.22.tgz",
+      "integrity": "sha512-mJ1goOs36mLx+VPYBtAm949H0Br6OXuJ9gwqtCYr2paNophYBsheE/BREiOwrWudqrjttICHBG5ubffEeu3YnQ=="
     },
     "call-bind": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "cafe-args": "^1.0.19",
+        "cafe-args": "1.0.21",
         "omelette": "0.4.15-1",
         "reflect-metadata": "^0.1.13"
       },
@@ -3327,9 +3327,9 @@
       }
     },
     "node_modules/cafe-args": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.19.tgz",
-      "integrity": "sha512-PS63Mu2SFI7ats6wvxoMFJZFqBkoDHlxv2FKYHTbo7ZST1VlR4t6bHbh4ftmEH65Xe7m1sCoCqCtLd6C8qzLmA=="
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.21.tgz",
+      "integrity": "sha512-cuDGWb5xjoGNrzZ6L2vfd0jn+9ZWj5j0d0O/SOZlLxlgiPxewmnh95vYwtOgvCOrEHtiVr76/O5FbVITMXHKcw=="
     },
     "node_modules/call-bind": {
       "version": "1.0.0",
@@ -5245,9 +5245,9 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -10155,9 +10155,9 @@
       }
     },
     "node_modules/trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -13921,9 +13921,9 @@
       }
     },
     "cafe-args": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.19.tgz",
-      "integrity": "sha512-PS63Mu2SFI7ats6wvxoMFJZFqBkoDHlxv2FKYHTbo7ZST1VlR4t6bHbh4ftmEH65Xe7m1sCoCqCtLd6C8qzLmA=="
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.21.tgz",
+      "integrity": "sha512-cuDGWb5xjoGNrzZ6L2vfd0jn+9ZWj5j0d0O/SOZlLxlgiPxewmnh95vYwtOgvCOrEHtiVr76/O5FbVITMXHKcw=="
     },
     "call-bind": {
       "version": "1.0.0",
@@ -15452,9 +15452,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -19405,9 +19405,9 @@
       }
     },
     "trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
     "trim-off-newlines": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "webpack-cli": "^4.3.0"
   },
   "dependencies": {
-    "cafe-args": "1.0.19",
+    "cafe-args": "1.0.21",
     "omelette": "0.4.15-1",
     "reflect-metadata": "^0.1.13"
   }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "webpack-cli": "^4.3.0"
   },
   "dependencies": {
-    "cafe-args": "1.0.21",
+    "cafe-args": "1.0.22",
     "omelette": "0.4.15-1",
     "reflect-metadata": "^0.1.13"
   }

--- a/src/argument.ts
+++ b/src/argument.ts
@@ -10,7 +10,7 @@ export interface IArgument<T = unknown> {
   description: string
   type?: string
   alias?: string
-  required?: boolean
+  required?: boolean | { when: string } | { unless: string }
   default?: T
   minimum?: number | bigint
   maximum?: number | bigint

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ class CommandBuilder {
   public initedCommands: InitedCommand[]
   public runnable?: LeafCommand
   public parser: Argv.Parser
-  public context!: Argv.Context
+  public context!: Argv.Context | string
 
   public constructor(parser: Argv.Parser) {
     this.parser = parser
@@ -159,12 +159,13 @@ class CommandBuilder {
       await autocomplete(this.parser, options.application?.command)
     }
 
-    this.context = await this.parser.parse(argv)
-    sourcemap = this.context.sourcemap
+    this.context = this.parser.parse(argv)
 
-    if (this.context.exitReason || typeof this.context === 'string' || !this.context.command?.meta?.instance) {
+    if (typeof this.context === 'string' || this.context.exitReason || !this.context.command?.meta?.instance) {
       return
     }
+
+    sourcemap = this.context.sourcemap
 
     const command = this.context.command.meta.instance as Command
 

--- a/src/option.ts
+++ b/src/option.ts
@@ -10,7 +10,7 @@ export interface IOption<T = unknown> {
   description: string
   type?: string
   alias?: string
-  required?: boolean
+  required?: boolean | { when: string } | { unless: string }
   default?: T
   minimum?: number | bigint
   maximum?: number | bigint


### PR DESCRIPTION
When an option is required, you can simply specify `{ required: true }` and the parser will print a helpful error message every time the user tries running your application without providing that option.

This may not always be your use-case though. Let's say you have an `--interactive` global option, which enables some features, such as allowing the user to provide a value (for that option) in your application logic, after the parser has run.

For such cases, the `required` property can take `{ when: string }` and `{ unless: string }` values, where the strings represent the dependee keys.

Following the previous example, you may want to specify `{ required: { unless: 'interactive' } }`, and the option will no longer throw error when running with the `--interactive` option (or its alias).

The reverse of this situation when you have these features enabled by default, but your application has a `--silent` or `--quiet` mode, where you do not allow any interactivity and the required options must all be passed beforehand. To indicate this, use `{ required: { when: 'quiet' } }`.